### PR TITLE
Delete WireGuard config file after setup

### DIFF
--- a/.github/workflows/test-setup-wireguard.yml
+++ b/.github/workflows/test-setup-wireguard.yml
@@ -64,6 +64,15 @@ jobs:
         run: |
           curl --fail http://192.168.4.1
 
+      - name: Verify Config File Removal
+        run: |
+          if [ -f wg0.conf ]; then
+            echo "Error: wg0.conf file exists when it should have been deleted."
+            exit 1
+          else
+            echo "Success: wg0.conf file has been deleted."
+          fi
+
   test-invalid-config:
     name: Test with Invalid Configuration
     needs: generate-config
@@ -100,3 +109,13 @@ jobs:
         run: |
           echo "Test failed: action did not fail as expected."
           exit 1
+
+      - name: Verify Config File Removal on Failure
+        if: ${{ steps.invalid_test.outcome == 'failure' }}
+        run: |
+          if [ -f wg0.conf ]; then
+            echo "Error: wg0.conf file exists after action failure."
+            exit 1
+          else
+            echo "Success: wg0.conf file does not exist after action failure."
+          fi

--- a/setup-wireguard/action.yml
+++ b/setup-wireguard/action.yml
@@ -13,6 +13,9 @@ runs:
         echo "${{ inputs.wireguard-configuration }}" > wg0.conf
         sudo chmod 600 wg0.conf
 
+        # Ensure wg0.conf is deleted on exit
+        trap 'rm -f wg0.conf' EXIT
+
         if grep -E '^\s*(PreUp|PostUp|PreDown|PostDown)\s*=' wg0.conf >/dev/null; then
           echo "Error: Configuration contains disallowed and potentially dangerous directives (PreUp, PostUp, PreDown, PostDown)."
           exit 1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
The `wg0.conf` file remains in the working directory after WireGuard has been set up and can unintentionally be processed by consecutive actions in the calling workflow if not manually excluded, e.g., included in builds or shipped to remote servers.


**What is the new behavior (if this is a feature change)?**
The `wg0.conf` file is deleted after WireGuard is set up.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Props @o-samaras for spotting it.