### PR TITLE
Remove openresolv package

### DIFF
--- a/setup-wireguard/action.yml
+++ b/setup-wireguard/action.yml
@@ -21,7 +21,7 @@ runs:
           exit 1
         fi
 
-        sudo apt-get update && sudo apt-get install -y wireguard-tools openresolv
+        sudo apt-get update && sudo apt-get install -y wireguard-tools
 
         sudo wg-quick up ./wg0.conf
       shell: bash


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
Package `openresolv` is not available more.
https://bugs.launchpad.net/ubuntu/+source/resolvconf/+bug/1990743


**What is the new behavior (if this is a feature change)?**
This PR updates the WireGuard setup GitHub Action by removing the installation of the `openresolv` package, which is no longer available on Ubuntu 24.04. Instead, the action now relies the default DNS management system `systemd-resolved`, which is included by default.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
